### PR TITLE
chore: add winner submissions, links to repos

### DIFF
--- a/submissions.md
+++ b/submissions.md
@@ -1,0 +1,41 @@
+# Hackathon Submissions
+
+## Winners
+
+### Best Overall
+Team 10: Airkita
+Repo: https://github.com/vivdlu/airkita_master
+
+### Best Security
+Team 12: H2Flow 
+Repo: https://github.com/christinelfrank16/H2Flow
+
+### Best Design
+Team 5: Homeostasis
+Repo: https://github.com/parksoy/WWCode_Hackathon_2019_team5
+
+## All Submissions
+
+Team 1: Alfred
+Repo: https://github.com/adyst/wwchack_team1
+
+Team 3: Bright Future
+Repo: https://github.com/chavissabin/TeamBrightFuture
+
+Team 4: DryFi
+Repo: https://github.com/jbatara/DryFi
+
+Team 6: Compostr
+Repo: https://github.com/b-marie/IoTHackathon2019
+
+Team 7: Human Comfort System
+Repo: https://github.com/Snerdette/WWC_2019_HACKATHON_7
+
+Team 8: My Eco Window
+Repo: http://github.com/dnguyen8/WWC-Hackathon2019-Group8
+
+Team 9: Shower Power
+Repos: https://github.com/Shower-Power
+
+Team 13: Solar Management
+Repo: https://github.com/argira/team13solarmanagement


### PR DESCRIPTION
This PR adds the hackathon winners and submissions to the 2019 repo, so we don't lose the project when our Slack history runs out.